### PR TITLE
Fix File pathing on Non linux systems

### DIFF
--- a/.changeset/slimy-olives-pretend.md
+++ b/.changeset/slimy-olives-pretend.md
@@ -1,0 +1,5 @@
+---
+"svelte-adapter-fastly": patch
+---
+
+Fix file pathing on non linux systems

--- a/README.md
+++ b/README.md
@@ -49,35 +49,34 @@ Due to its nature as an edgeworker Fastly needs to compile static assets to be s
 
 You can supply a custom entry file if you want to add middleware before SvelteKit is called, or just want greater customization of the edgeworker.
 
-You can do this by importing `handleSvelteKitRequest` into your entry file. 
+You can do this by importing `handleSvelteKitRequest` into your entry file.
 
 ```js
-//entry.js 
-import { handleSvelteKitRequest } from "svelte-adapter-fastly"
+//entry.js
+import { handleSvelteKitRequest } from "svelte-adapter-fastly";
 
 /// <reference types="@fastly/js-compute" />
-addEventListener("fetch", event => event.respondWith(handleRequest(event)));
+addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 /**
  * @param {FetchEvent} event
  */
 async function handleRequest(event) {
-    // Get the request from the client.
-    const req = event.request;
+  // Get the request from the client.
+  const req = event.request;
 
-    const headers = new Headers();
-    headers.set('Content-Type', 'text/plain');
+  const headers = new Headers();
+  headers.set("Content-Type", "text/plain");
 
-    //Requests with edge in URL will return plain non sveltekit response
-    if (req.url.includes("edge")) {
-        return new Response("Hi from the edge", {
-            status: 200,
-            headers
-        })
-    }
-    else {
-        //everyone else gets the kit!
-        return handleSvelteKitRequest(event);
-    }
+  //Requests with edge in URL will return plain non sveltekit response
+  if (req.url.includes("edge")) {
+    return new Response("Hi from the edge", {
+      status: 200,
+      headers,
+    });
+  } else {
+    //everyone else gets the kit!
+    return handleSvelteKitRequest(event);
+  }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ export default function (opts = {}) {
       const tmp = builder.getBuildDirectory("fastly-tmp");
       builder.rimraf(tmp);
       builder.rimraf(out);
+      builder.mkdirp(tmp);
       builder.log.minor("Copying Static assets...");
       //copy static assests to tmp directory
       const static_dir = `${tmp}/static`;
@@ -59,7 +60,7 @@ export default function (opts = {}) {
         {
           replace: {
             SERVER: `${workerRelativePath}/index.js`,
-            MANIFEST: `${tmp}/manifest.js`,
+            MANIFEST: `../manifest.js`,
             STATICS: `../static-publisher/statics.js`,
           },
         }


### PR DESCRIPTION
The pathing set up for imports of manifest were bugged and not relative, causing problems on windows systems made manifest import relative in hopes of fixing it.  #32 